### PR TITLE
Update /code command to include username only

### DIFF
--- a/botCommands/help.js
+++ b/botCommands/help.js
@@ -19,7 +19,7 @@ I'm open source!  Hack me HERE: <https://github.com/codyloyd/odin-bot-v2>`;
 registerBotCommand(/\B\/code\b/, async ({ room, mentions }) => {
   let users = '';
   if (mentions.users) {
-    for (user of mentions.users) users += `${user} `;
+    for (user of mentions.users) users += `${user[1]} `;
   }
 
   return `


### PR DESCRIPTION
When mentioning a user with `/code`, the bot would read back the user id and then mentioned id. Changed the for loop to append just the mentioned id instead of the plain id.